### PR TITLE
Add initialization scripts for cluster which consists of nodes and pool

### DIFF
--- a/python_scripts/e2e_scenarios/constants.py
+++ b/python_scripts/e2e_scenarios/constants.py
@@ -1,7 +1,27 @@
+import os
+
+CWD = os.getcwd()
+
 TESTNET_MAGIC = "42"
-NODE_SOCKET_PATH = "/root/cardano-node/example/node-pool1/node.sock"
-GENESIS = "genesis.json"
-PROTOCOL_PARAMS = "protocol-params.json"
-USER1_ADDRESS = "0015195ff291b568d13a845673f9835ca4ce36edb1adddfb3ac8d7b43375ae5b2006c8f846c3f489a770cbe0b03f0d78e05787e05022032c671da718d65855cc67"
-USER1_SKEY_FILE_PATH = "/root/cardano-node/example/addresses/user1.skey"
-USER1_VKEY_FILE_PATH = "/root/cardano-node/example/addresses/user1.vkey"
+SOCKET_FILE_NAME = "node.sock"
+
+TESTS_ROOT_DIR_NAME = "e2e-tests-directory"
+TESTS_ROOT_DIR_PATH = os.path.join(CWD, TESTS_ROOT_DIR_NAME)
+
+ADDRESSES_DIR_NAME = "addresses"
+ADDRESSES_DIR_PATH = os.path.join(TESTS_ROOT_DIR_PATH, ADDRESSES_DIR_NAME)
+
+POOL_1_DIR_NAME = "node-pool1"
+POOL_1_DIR_PATH = os.path.join(TESTS_ROOT_DIR_PATH, POOL_1_DIR_NAME)
+
+SOCKET_FILE_NAME = "node.sock"
+NODE_SOCKET_PATH = os.path.join(POOL_1_DIR_PATH, SOCKET_FILE_NAME)
+
+GENESIS_FILE_NAME = "genesis.json"
+GENESIS_FILE_PATH = os.path.join(TESTS_ROOT_DIR_PATH, GENESIS_FILE_NAME)
+
+PROTOCOL_PARAMS_FILENAME = "protocol-params.json"
+PROTOCOL_PARAMS_FILEPATH = os.path.join(TESTS_ROOT_DIR_PATH, PROTOCOL_PARAMS_FILENAME)
+
+USER1_SKEY_FILE_PATH = os.path.join(ADDRESSES_DIR_PATH, "user1.skey")
+USER1_VKEY_FILE_PATH = os.path.join(ADDRESSES_DIR_PATH, "user1.vkey")

--- a/python_scripts/e2e_scenarios/transaction_basic_test.py
+++ b/python_scripts/e2e_scenarios/transaction_basic_test.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+#!/usr/bin/env python2
+
 import os, sys
 import time
 from pathlib import Path
@@ -6,7 +9,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 parent_dir_path = os.path.abspath(os.path.join(dir_path, os.pardir))
 sys.path.insert(0, parent_dir_path)
 
-from e2e_scenarios.constants import USER1_ADDRESS, USER1_SKEY_FILE_PATH
+from e2e_scenarios.constants import ADDRESSES_DIR_PATH, USER1_SKEY_FILE_PATH
 from e2e_scenarios.utils import create_payment_key_pair_and_address, calculate_tx_fee, calculate_tx_ttl, \
     build_raw_transaction, get_utxo_with_highest_value, send_funds, read_address_from_file, get_address_balance, \
     wait_for_new_tip, assert_address_balance
@@ -36,7 +39,7 @@ print(f"first_address: {first_address_name}")
 
 print(f"=== Step2: Send funds from user1 (faucet) to one of the newly created addresses")
 
-src_address = USER1_ADDRESS
+src_address = read_address_from_file(ADDRESSES_DIR_PATH, "user1")
 dst_addresses_list = [created_addresses_dict.get(first_address_name)]
 transferred_amounts_list = [2000]
 signing_keys_list = [USER1_SKEY_FILE_PATH]

--- a/python_scripts/e2e_scenarios/utils.py
+++ b/python_scripts/e2e_scenarios/utils.py
@@ -4,7 +4,7 @@ import subprocess
 import os
 from time import sleep
 
-from e2e_scenarios.constants import TESTNET_MAGIC, PROTOCOL_PARAMS, NODE_SOCKET_PATH, USER1_ADDRESS
+from e2e_scenarios.constants import TESTNET_MAGIC, PROTOCOL_PARAMS_FILEPATH, NODE_SOCKET_PATH
 
 
 def delete_folder(location_offline_tx_folder):
@@ -60,7 +60,7 @@ def get_protocol_params():
     try:
         cmd = "cardano-cli shelley query protocol-parameters" \
               " --testnet-magic " + TESTNET_MAGIC + \
-              " --out-file " + PROTOCOL_PARAMS
+              " --out-file " + PROTOCOL_PARAMS_FILEPATH
         return subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode("utf-8").strip()
     except subprocess.CalledProcessError as e:
         raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
@@ -149,7 +149,7 @@ def calculate_tx_fee(tx_in_count, tx_out_count, ttl, **options):
           " --tx-in-count " + str(tx_in_count) + \
           " --tx-out-count " + str(tx_out_count) + \
           " --ttl " + str(ttl) + \
-          " --protocol-params-file " + PROTOCOL_PARAMS
+          " --protocol-params-file " + PROTOCOL_PARAMS_FILEPATH
     try:
         if options.get("signing_keys"):
             signing_keys = options.get('signing_keys')

--- a/python_scripts/init-blockchain.sh
+++ b/python_scripts/init-blockchain.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+
+set -e
+#set -x
+
+testnet_magic=42
+root=e2e-tests-directory
+
+init_blockchain_txs_dir_name=init_blockchain_txs
+
+if [ -d $root ]; then
+    rm -rf $root
+fi
+
+bft_nodes="node-bft1 node-bft2"
+bft_nodes_N="1 2"
+num_bft_nodes=2
+
+pool_nodes="node-pool1"
+
+all_nodes="$bft_nodes $pool_nodes"
+
+if ! mkdir "$root"; then
+  echo "The $root directory already exists, please move or remove it"
+  exit
+fi
+
+mkdir "$root/$init_blockchain_txs_dir_name"
+
+# copy and tweak the configuration
+cp configuration/defaults/byron-mainnet/configuration.yaml $root/
+sed -i $root/configuration.yaml \
+    -e 's/Protocol: RealPBFT/Protocol: TPraos/' \
+    -e 's/minSeverity: Info/minSeverity: Debug/'
+
+# Set up our template
+cardano-cli shelley genesis create --testnet-magic $testnet_magic --genesis-dir $root
+
+# Then edit the genesis.spec.json ...
+
+supply=1000000000000
+
+# We're going to use really quick epochs (300 seconds), by using short slots 0.2s
+# and K=10, but we'll keep long KES periods so we don't have to bother
+# cycling KES keys
+sed -i $root/genesis.spec.json \
+    -e 's/"slotLength": 1/"slotLength": 0.1/' \
+    -e 's/"activeSlotsCoeff": 5.0e-2/"activeSlotsCoeff": 0.1/' \
+    -e 's/"securityParam": 2160/"securityParam": 10/' \
+    -e 's/"epochLength": 432000/"epochLength": 1500/' \
+    -e 's/"maxLovelaceSupply": 0/"maxLovelaceSupply": 1000000000000/' \
+    -e 's/"decentralisationParam": 1/"decentralisationParam": 0.7/' \
+    -e 's/"minFeeA": 0/"minFeeA": 44/' \
+    -e 's/"minFeeB": 0/"minFeeB": 155381/' \
+    -e 's/"keyDeposit": 0/"keyDeposit": 400000/' \
+    -e 's/"poolDeposit": 0/"poolDeposit": 5000000/'
+
+
+# Now generate for real:
+
+cardano-cli shelley genesis create \
+    --testnet-magic $testnet_magic \
+    --genesis-dir $root/ \
+    --gen-genesis-keys $num_bft_nodes \
+    --gen-utxo-keys 1
+
+pushd $root
+
+echo "====================================================================="
+echo "Generated genesis keys and genesis files:"
+echo
+ls -1 *
+echo "====================================================================="
+
+echo "Generated genesis.json:"
+echo
+cat genesis.json
+echo
+echo "====================================================================="
+
+mkdir $all_nodes
+
+# Make the pool operator cold keys
+# This was done already for the BFT nodes as part of the genesis creation
+
+for node in $pool_nodes; do
+
+  cardano-cli shelley node key-gen \
+      --cold-verification-key-file                 $node/operator.vkey \
+      --cold-signing-key-file                      $node/operator.skey \
+      --operational-certificate-issue-counter-file $node/operator.counter
+
+  cardano-cli shelley node key-gen-VRF \
+      --verification-key-file $node/vrf.vkey \
+      --signing-key-file      $node/vrf.skey
+
+done
+
+# Symlink the BFT operator keys from the genesis delegates, for uniformity
+
+for n in $bft_nodes_N; do
+
+  ln -s ../delegate-keys/delegate$n.skey node-bft$n/operator.skey
+  ln -s ../delegate-keys/delegate$n.vkey node-bft$n/operator.vkey
+  ln -s ../delegate-keys/delegate$n.counter node-bft$n/operator.counter
+  ln -s ../delegate-keys/delegate$n.vrf.vkey node-bft$n/vrf.vkey
+  ln -s ../delegate-keys/delegate$n.vrf.skey node-bft$n/vrf.skey
+
+done
+
+
+# Make hot keys and for all nodes
+
+for node in ${all_nodes}; do
+
+  cardano-cli shelley node key-gen-KES \
+      --verification-key-file $node/kes.vkey \
+      --signing-key-file      $node/kes.skey
+
+  cardano-cli shelley node issue-op-cert \
+      --kes-period 0 \
+      --kes-verification-key-file                  $node/kes.vkey \
+      --cold-signing-key-file                      $node/operator.skey \
+      --operational-certificate-issue-counter-file $node/operator.counter \
+      --out-file                                   $node/node.cert
+
+done
+
+# Make topology files
+#TODO generalise this over the N BFT nodes and pool nodes
+(cat <<TOPOLOGY_FILE
+{
+   "Producers": [
+     {
+       "addr": "127.0.0.1",
+       "port": 3002,
+       "valency": 1
+     }
+   , {
+       "addr": "127.0.0.1",
+       "port": 3003,
+       "valency": 1
+     }
+   ]
+ }
+TOPOLOGY_FILE
+) > node-bft1/topology.json
+echo 3001 > node-bft1/port
+
+(cat <<TOPOLOGY_FILE
+{
+   "Producers": [
+     {
+       "addr": "127.0.0.1",
+       "port": 3001,
+       "valency": 1
+     }
+   , {
+       "addr": "127.0.0.1",
+       "port": 3003,
+       "valency": 1
+     }
+   ]
+ }
+TOPOLOGY_FILE
+) > node-bft2/topology.json
+echo 3002 > node-bft2/port
+
+(cat <<TOPOLOGY_FILE
+{
+   "Producers": [
+     {
+       "addr": "127.0.0.1",
+       "port": 3001,
+       "valency": 1
+     }
+   , {
+       "addr": "127.0.0.1",
+       "port": 3002,
+       "valency": 1
+     }
+   ]
+ }
+TOPOLOGY_FILE
+) > node-pool1/topology.json
+echo 3003 > node-pool1/port
+
+
+echo "Generated node operator keys (cold, hot) and operational certs:"
+echo
+ls -1 $all_nodes
+echo "====================================================================="
+
+
+# Make some payment and stake addresses
+# user1..n:       will own all the funds in the system, we'll set this up from
+#                 initial utxo the
+# pool-owner1..n: will be the owner of the pools and we'll use their reward
+#                 account for pool rewards
+
+user_addrs="user1"
+pool_addrs="pool-owner1"
+
+addrs="$user_addrs $pool_addrs"
+
+mkdir addresses
+
+for addr in $addrs; do
+
+  # Payment address keys
+  cardano-cli shelley address key-gen \
+      --verification-key-file addresses/$addr.vkey \
+      --signing-key-file      addresses/$addr.skey
+
+  # Stake address keys
+  cardano-cli shelley stake-address key-gen \
+      --verification-key-file addresses/$addr-stake.vkey \
+      --signing-key-file      addresses/$addr-stake.skey
+
+  # Payment addresses
+  cardano-cli shelley address build \
+      --payment-verification-key-file addresses/$addr.vkey \
+      --stake-verification-key-file addresses/$addr-stake.vkey \
+      --testnet-magic $testnet_magic \
+      --out-file addresses/$addr.addr
+
+  # Stake addresses
+  cardano-cli shelley stake-address build \
+      --stake-verification-key-file addresses/$addr-stake.vkey \
+      --testnet-magic $testnet_magic \
+      --out-file addresses/$addr-stake.addr
+
+  # Stake addresses registration certs
+  cardano-cli shelley stake-address registration-certificate \
+      --stake-verification-key-file addresses/$addr-stake.vkey \
+      --out-file addresses/$addr-stake.reg.cert
+
+done
+
+# user N will delegate to pool N
+user_pool_n="1"
+
+for n in $user_pool_n; do
+
+  # Stake address delegation certs
+  cardano-cli shelley stake-address delegation-certificate \
+      --stake-verification-key-file addresses/user$n-stake.vkey \
+      --cold-verification-key-file  node-pool$n/operator.vkey \
+      --out-file addresses/user$n-stake.deleg.cert
+
+  ln -s ../addresses/pool-owner$n-stake.vkey node-pool$n/owner.vkey
+  ln -s ../addresses/pool-owner$n-stake.skey node-pool$n/owner.skey
+
+done
+
+echo "Generated payment address keys, stake address keys,"
+echo "stake address regitration certs, and stake address delegatation certs"
+echo
+ls -1 addresses/
+echo "====================================================================="
+
+
+# Next is to make the stake pool registration cert
+
+for node in $pool_nodes; do
+
+  cardano-cli shelley stake-pool registration-certificate \
+    --testnet-magic $testnet_magic \
+    --pool-pledge 1000000 --pool-cost 2000000 --pool-margin 0.7 \
+    --cold-verification-key-file             $node/operator.vkey \
+    --vrf-verification-key-file              $node/vrf.vkey \
+    --reward-account-verification-key-file   $node/owner.vkey \
+    --pool-owner-stake-verification-key-file $node/owner.vkey \
+    --out-file                               $node/registration.cert
+done
+
+echo "Generated stake pool registration certs:"
+ls -1 node-*/registration.cert
+echo "====================================================================="
+
+
+fee=1000000
+change=$(( supply - fee ))
+
+cardano-cli shelley transaction build-raw \
+    --ttl 1000 \
+    --fee $fee \
+    --tx-in $(cardano-cli shelley genesis initial-txin \
+                --testnet-magic $testnet_magic \
+                --verification-key-file utxo-keys/utxo1.vkey) \
+    --tx-out "$(cat addresses/user1.addr)+$change" \
+    --out-file $init_blockchain_txs_dir_name/tx1.txbody
+
+
+cardano-cli shelley transaction sign \
+   --signing-key-file utxo-keys/utxo1.skey \
+   --testnet-magic $testnet_magic \
+   --tx-body-file  $init_blockchain_txs_dir_name/tx1.txbody \
+   --out-file      $init_blockchain_txs_dir_name/tx1.tx
+
+echo "Generated a signed transaction that transfer all funds from initial utxo to address 1:"
+ls -1 $init_blockchain_txs_dir_name/tx1.tx
+
+run_cmds=()
+
+for node in $all_nodes; do
+    run_cmd="cardano-node run --config $root/configuration.yaml --topology $root/$node/topology.json --database-path $root/$node/db --socket-path $root/$node/node.sock --shelley-kes-key $root/$node/kes.skey --shelley-vrf-key $root/$node/vrf.skey --shelley-operational-certificate $root/$node/node.cert --port $(cat ${node}/port)"
+    run_cmds+=("$run_cmd")
+done
+
+echo "Wait until epoch #2 (counting from 0) starting at slot 3000"
+echo "to query the stake distribution, and see if the pool node creates blocks"
+echo
+echo "CARDANO_NODE_SOCKET_PATH=$root/node-bft1/node.sock \\"
+echo "  cardano-cli shelley query stake-distribution --testnet-magic 42"
+echo
+
+popd
+
+if ! which tmux > /dev/null; then
+    echo "This script requires tmux to be installed on a machine"
+    exit 1
+fi
+
+session_name="TA Shelley Blockchain"
+tmux new-session -d -s "$session_name"
+
+tmux split-window -h
+tmux split-window -v -t 0
+tmux split-window -v -t 2
+
+for i in $(seq 0 ${#run_cmds[@]}); do
+    tmux select-pane -t "$i"
+    tmux send-keys -t "$session_name"  "${run_cmds[$i]}" C-m
+done
+
+tmux select-pane -t 3
+tmux send-keys -t "$session_name" "./python_scripts/submit-initial-blockchain-transaction.sh" C-m
+tmux send-keys -t "$session_name" "sleep 3; ./python_scripts/tests-runner.sh" C-m
+
+# For debugging: attach session
+tmux attach -t "$session_name"

--- a/python_scripts/submit-initial-blockchain-transaction.sh
+++ b/python_scripts/submit-initial-blockchain-transaction.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+testnet_magic=42
+pool_deposit=5000000
+key_deposit=400000
+
+root=e2e-tests-directory
+output_log_filename=output.log
+output_log_filepath=$root/$output_log_filename
+
+addresses_dir_path=$root/addresses
+user1_payment_address_filename=user1.addr
+user1_payment_address_filepath=$addresses_dir_path/$user1_payment_address_filename
+
+pool1_dirpath=$root/node-pool1
+utxo_keys_dirpath=$root/utxo-keys
+
+init_blockchain_txs_dir_name=$root/init_blockchain_txs
+
+echo "======================== submit-initial-blockchain-transaction.sh ========================" 2>&1 | tee -a $output_log_filepath
+
+sleep 30
+
+echo "Submitting first transaction ever to transfer all funds from intial UTXO to addr1" 2>&1 | tee -a $output_log_filepath
+export CARDANO_NODE_SOCKET_PATH=$root/node-bft1/node.sock
+$(cardano-cli shelley transaction submit --tx-file $init_blockchain_txs_dir_name/tx1.tx --testnet-magic $testnet_magic 2>&1 | tee -a $output_log_filepath)
+
+if [ $?	== 1 ]; then
+    echo "Error when submitting transaction"
+    exit 1
+fi
+
+# Wait a bit afee submission
+sleep 3
+
+echo "Submitting first transaction was successful" 2>&1 | tee -a $output_log_filepath
+
+# Select some fee that will satisfy conditions
+fee=3000000
+tx=$(cardano-cli shelley query utxo --testnet-magic $testnet_magic --address $(cat $user1_payment_address_filepath) | grep "^[^- ]" | sort -k 2n | tail -1)
+utxo=$(echo $tx | awk -F' ' '{print $1}')
+id=$(echo $tx | awk -F' ' '{print $2}')
+balance=$(echo $tx | awk -F' ' '{print $3}')
+change=$(( balance - fee - (2 * $key_deposit) - $pool_deposit))
+input="${utxo}#${id}"
+
+
+echo "Creating second transaction in order to register all certificates and stake pool" 2>&1 | tee -a $output_log_filepath
+echo "TX input: $input" 2>&1 | tee -a $output_log_filepath
+echo "TX balance: $balance" 2>&1 | tee -a $output_log_filepath
+echo "TX change: $change" 2>&1 | tee -a $output_log_filepath
+
+cardano-cli shelley transaction build-raw \
+    --ttl 10000 \
+    --fee $fee \
+    --tx-in $input \
+    --tx-out "$(cat $user1_payment_address_filepath)+${change}" \
+    --certificate-file $addresses_dir_path/pool-owner1-stake.reg.cert \
+    --certificate-file $pool1_dirpath/registration.cert \
+    --certificate-file $addresses_dir_path/user1-stake.reg.cert \
+    --certificate-file $addresses_dir_path/user1-stake.deleg.cert \
+    --out-file $init_blockchain_txs_dir_name/tx2.txbody
+
+if [ $?	== 1 ]; then
+    echo "Error when building raw transaction"
+    exit 1
+fi
+
+# We'll need to sign this with a bunch of keys:
+# 1. the initial utxo spending key, for the funds
+# 2. the user1 stake address key, due to the delegatation cert
+# 3. the pool1 owner key, due to the pool registration cert
+# 3. the pool1 operator key, due to the pool registration cert
+
+cardano-cli shelley transaction sign \
+   --signing-key-file $addresses_dir_path/user1.skey \
+   --signing-key-file $utxo_keys_dirpath/utxo1.skey \
+   --signing-key-file $addresses_dir_path/user1-stake.skey \
+   --signing-key-file $pool1_dirpath/owner.skey \
+   --signing-key-file $pool1_dirpath/operator.skey \
+   --testnet-magic $testnet_magic \
+   --tx-body-file  $init_blockchain_txs_dir_name/tx2.txbody \
+   --out-file      $init_blockchain_txs_dir_name/tx2.tx
+
+if [ $?	== 1 ]; then
+    echo "Error when signing transaction"
+    exit 1
+fi
+
+echo "Submitting second transaction to register stake address 1 and stake pool 1" 2>&1 | tee -a $output_log_filepath
+
+cardano-cli shelley transaction submit --tx-file $init_blockchain_txs_dir_name/tx2.tx --testnet-magic $testnet_magic 2>&1 | tee -a $output_log_filepath
+
+if [ $?	== 1 ]; then
+    echo "Error when submitting transaction"
+    exit 1
+fi
+
+echo "Submitting second transaction was successful" 2>&1 | tee -a $output_log_filepath

--- a/python_scripts/tests-runner.sh
+++ b/python_scripts/tests-runner.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+root=e2e-tests-directory
+output_log_filename=output.log
+output_log_filepath=$root/$output_log_filename
+
+tests_results_filename=tests-results.txt
+tests_results_filepath=$root/$tests_results_filename
+
+tests_dir_path=python_scripts/e2e_scenarios
+
+echo "======================== test-runner.sh ========================" 2>&1 | tee -a $output_log_filepath
+
+# List of test scripts to run:
+
+
+tests=$(ls -1 $tests_dir_path | grep test.py)
+
+for test in $tests; do
+    ./$tests_dir_path/$test 2>&1 | tee -a $output_log_filepath
+    echo "$test:${PIPESTATUS[0]}" >> $tests_results_filepath
+done
+
+#tmux kill-server


### PR DESCRIPTION
Copy `python_scripts` to `cardano-node` and run:
`./python_scripts/init-blockchain.sh`

It should:
- `init-blockchain.sh` - creates 3 nodes: 1 pool and 2 bft nodes (based on mkfiles scripts) with non zero values for cert / key / tx / pool deposit fees and etc. and starts tmux session with 4 panes (just uncomment last line to run in detached mode otherwise tmux session will be visible inside console shell. 
- `submit-initial-blockchain-transaction.sh` - then within `init-blockchain.sh` it will submit initial txs - 1st one for funds transfer to address1 and second one for registartion of pool certs, stake address1 etc. `using submit-initial-blockchain-transaction.sh`
- then last step is to run `tests-runner.sh` that conatins tests (currently one for transaction).

OUTCOME:

After running `e2e-tests-directory` will be created with all keys and files and also:
- output.log - all logs should be there for initial scripts creating blockchain/cluster and then tests
- tests-results.txt - file with tests results in key pair format `test name:test result` Example: `transaction_basic_test.py:0`


